### PR TITLE
Added Techorama Belgium in May of 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@
 
 ### July
 - [Chain React](https://infinite.red/ChainReactConf) - July 11-12 in Portland, OR
+- [Kansas City Developer Conference](http://www.kcdc.info/) - July 17-19 in Kansas City, MO
 - [Laracon](https://laracon.us/) - July 24-25 in New York, NY
 - [An Event Apart Washington, DC](https://aneventapart.com/event/washington-dc-2019) - July 29-31 in Washington, DC
 
@@ -116,6 +117,7 @@
 
 ### Missouri
 - [Flyover Conf](https://www.flyovercamp.org/) - May 31-June 2 in Kansas City, MO
+- [Kansas City Developer Conference](http://www.kcdc.info/) - July 17-19 in Kansas City, MO
 
 ### Montana
 - [Rails Camp West](https://west.railscamp.us/) - August 23-26 in McLeod, MT

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@
 - [ng-conf](https://www.ng-conf.org/) - May 1-3 in Salt Lake City, UT
 - [An Event Apart Boston](https://aneventapart.com/event/boston-2019) - May 6-8 in Boston, MA
 - [NDC Minnesota](https://ndcminnesota.com/) - May 6-9 in St. Paul, MN
+- [Techorama](https://techorama.be/) - May 20-22 in Antwerp, Belgium
 - [Flyover Conf](https://www.flyovercamp.org/) - May 31-June 2 in Kansas City, MO
 
 ### June
@@ -72,6 +73,9 @@
 
 ### Online
 - [Byteconf JavaScript](https://www.byteconf.com/js-2019) - March 1-2 streamed on Twitch
+
+### Outside Of United States
+- [Techorama](https://techorama.be/) - May 20-22 in Antwerp, Belgium
 
 ### Arizona
 - [WordCamp Phoenix](https://central.wordcamp.org/wordcamps/wordcamp-phoenix-az-2/) - February 15-17 in Phoenix, AZ


### PR DESCRIPTION
I added the Techorama Belgium conference (May 20-22, 2019), to the list, both in the month of May and under a new subsection under "By State" called "Outside Of United States". Link to repository (per pull request guidelines): https://github.com/karaluton/awesome-dev-conferences